### PR TITLE
Support meta key shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This extension allows you to write emails in Markdown when composing a message in Gmail. Convert the Markdown to rich text via the provided context menu item or with the keyboard shortcut `Ctrl+Shift+M`.
 
-An options page allows you to configure automatic conversion on paste, parser settings, and a custom keyboard shortcut.
+An options page allows you to configure automatic conversion on paste, parser settings, and a custom keyboard shortcut. The shortcut string recognizes `ctrl`, `shift`, `alt`, and `cmd`/`meta` tokens so macOS users can specify combinations like `cmd+shift+m`.
 
 ## Installation
 1. Clone this repository.

--- a/contentScript.js
+++ b/contentScript.js
@@ -35,10 +35,12 @@
     const ctrl = parts.includes('ctrl');
     const shift = parts.includes('shift');
     const alt = parts.includes('alt');
+    const meta = parts.includes('meta') || parts.includes('cmd');
     return e.key.toLowerCase() === key &&
            e.ctrlKey === ctrl &&
            e.shiftKey === shift &&
-           e.altKey === alt;
+           e.altKey === alt &&
+           e.metaKey === meta;
   }
 
   function observePaste(callback) {

--- a/options.html
+++ b/options.html
@@ -10,7 +10,7 @@
   <label><input type="checkbox" id="autoConvert"> Convert on Send</label><br>
   <label><input type="checkbox" id="gfm"> GitHub flavored Markdown</label><br>
   <label><input type="checkbox" id="sanitize"> Sanitize HTML</label><br>
-  <label>Custom Shortcut: <input type="text" id="shortcut" placeholder="Ctrl+Shift+M"></label><br>
+  <label>Custom Shortcut: <input type="text" id="shortcut" placeholder="Ctrl+Shift+M or Cmd+Shift+M"></label><br>
   <label><input type="checkbox" id="disableDefault"> Disable default shortcut</label><br>
   <button id="save">Save</button>
   <script src="options.js"></script>


### PR DESCRIPTION
## Summary
- handle `cmd`/`meta` tokens in shortcut parsing
- show Cmd+Shift+M in the options placeholder
- document Meta/Cmd shortcut support in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6853ff910188832391b0f9ed96cee6f3