### PR TITLE
Add Markdown toolbar

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -19,6 +19,8 @@
       observeSendButton(() => convertMarkdown(opts));
     }
 
+    observeComposeToolbar();
+
     if (shortcut) {
       document.addEventListener('keydown', (e) => {
         if (matchesShortcut(e, shortcut)) {
@@ -111,5 +113,69 @@
         emailBody.innerHTML = html;
       }
     });
+  }
+
+  function observeComposeToolbar() {
+    const observer = new MutationObserver(() => {
+      document.querySelectorAll('div[aria-label="Message Body"][contenteditable="true"]').forEach(body => {
+        if (!body.dataset.mdToolbarInjected) {
+          injectToolbar(body);
+          body.dataset.mdToolbarInjected = 'true';
+        }
+      });
+
+      document.querySelectorAll('.md-toolbar').forEach(toolbar => {
+        const parentBodyId = toolbar.getAttribute('data-body-id');
+        const body = document.querySelector(`div[aria-label="Message Body"][contenteditable="true"][data-body-id="${parentBodyId}"]`);
+        if (!body) {
+          toolbar.remove();
+        }
+      });
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+
+  function injectToolbar(body) {
+    const toolbar = document.createElement('div');
+    toolbar.className = 'md-toolbar';
+    toolbar.style.cssText = 'margin:4px 0;';
+    toolbar.setAttribute('data-body-id', Date.now().toString());
+    body.setAttribute('data-body-id', toolbar.getAttribute('data-body-id'));
+
+    const buttons = [
+      { label: 'B', wrap: '**' },
+      { label: 'I', wrap: '_' },
+      { label: 'Link', link: true },
+      { label: 'Code', wrap: '`' }
+    ];
+
+    buttons.forEach(btn => {
+      const el = document.createElement('button');
+      el.textContent = btn.label;
+      el.style.marginRight = '4px';
+      el.addEventListener('click', () => {
+        if (btn.link) {
+          const url = prompt('Enter URL');
+          if (url) wrapSelection(body, '[', `](${url})`);
+        } else {
+          wrapSelection(body, btn.wrap);
+        }
+      });
+      toolbar.appendChild(el);
+    });
+
+    body.parentNode.insertBefore(toolbar, body);
+  }
+
+  function wrapSelection(body, start, end) {
+    const sel = window.getSelection();
+    if (!sel.rangeCount) return;
+    const range = sel.getRangeAt(0);
+    if (!body.contains(range.commonAncestorContainer)) return;
+    if (end === undefined) end = start;
+    const text = sel.toString();
+    range.deleteContents();
+    range.insertNode(document.createTextNode(start + text + end));
   }
 })();


### PR DESCRIPTION
## Summary
- inject Markdown toolbar into compose window
- wrap selections with Markdown syntax via toolbar buttons
- remove toolbar when compose window closes

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68540089b4588323ae9c583a70335ece