### PR TITLE
Add HTML to Markdown conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ An options page allows you to configure automatic conversion on paste, parser se
 ## Usage
 - Compose a new email in Gmail and write your message using Markdown syntax.
 - Right-click inside the message body and choose **Convert Markdown to Rich Text**, or press `Ctrl+Shift+M`.
-- The extension will convert the Markdown to HTML within the compose area.
+- Use **Convert HTML to Markdown** from the context menu (or `Ctrl+Shift+H`) to reverse the conversion.
+- The extension will convert the Markdown to HTML within the compose area or convert existing HTML back to Markdown when requested.
 
 ## Development
 The conversion is performed using the [Marked](https://github.com/markedjs/marked) library which is bundled inside `injector.js`.

--- a/background.js
+++ b/background.js
@@ -4,6 +4,11 @@ chrome.runtime.onInstalled.addListener(() => {
     title: "Convert Markdown to Rich Text",
     contexts: ["editable"]
   });
+  chrome.contextMenus.create({
+    id: "convert-html-md",
+    title: "Convert HTML to Markdown",
+    contexts: ["editable"]
+  });
 });
 
 function injectMarkdownTools(tabId) {
@@ -18,9 +23,23 @@ function injectMarkdownTools(tabId) {
   });
 }
 
+function injectHtmlToMarkdown(tabId) {
+  chrome.scripting.executeScript({
+    target: { tabId },
+    files: ['turndown.js']
+  }, () => {
+    chrome.scripting.executeScript({
+      target: { tabId },
+      files: ['html2md.js']
+    });
+  });
+}
+
 chrome.contextMenus.onClicked.addListener((info, tab) => {
   if (info.menuItemId === "convert-md") {
     injectMarkdownTools(tab.id);
+  } else if (info.menuItemId === "convert-html-md") {
+    injectHtmlToMarkdown(tab.id);
   }
 });
 
@@ -31,6 +50,10 @@ chrome.commands.onCommand.addListener((command) => {
       chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
         injectMarkdownTools(tabs[0].id);
       });
+    });
+  } else if (command === "convert_html_markdown") {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      injectHtmlToMarkdown(tabs[0].id);
     });
   }
 });

--- a/html2md.js
+++ b/html2md.js
@@ -1,0 +1,32 @@
+(function(){
+  console.log('[Markdown4Gmail] html2md.js loaded');
+  const MAX_ATTEMPTS = 50;
+  let attempts = 0;
+
+  const interval = setInterval(() => {
+    const emailBody = document.querySelector('div[aria-label="Message Body"][contenteditable="true"]');
+    if(emailBody && typeof TurndownService !== 'undefined'){
+      clearInterval(interval);
+      const selection = window.getSelection();
+      const range = selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+      const td = new TurndownService();
+
+      if(range && emailBody.contains(range.commonAncestorContainer) && selection.toString().trim()){
+        const frag = range.cloneContents();
+        const div = document.createElement('div');
+        div.appendChild(frag);
+        const md = td.turndown(div.innerHTML);
+        range.deleteContents();
+        range.insertNode(document.createTextNode(md));
+      }else{
+        const md = td.turndown(emailBody.innerHTML);
+        emailBody.innerText = md;
+      }
+    }else{
+      attempts++;
+      if(attempts > MAX_ATTEMPTS){
+        clearInterval(interval);
+      }
+    }
+  },300);
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -26,11 +26,17 @@
         "default": "Ctrl+Shift+M"
       },
       "description": "Convert Markdown in email to rich text"
+    },
+    "convert_html_markdown": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+H"
+      },
+      "description": "Convert HTML in email to Markdown"
     }
   },
   "web_accessible_resources": [
     {
-      "resources": ["marked.min.js"],
+      "resources": ["marked.min.js", "turndown.js"],
       "matches": ["https://mail.google.com/*"]
     }
   ]

--- a/turndown.js
+++ b/turndown.js
@@ -1,0 +1,61 @@
+(function(){
+  function process(node){
+    var md = '';
+    node.childNodes.forEach(function(child){
+      if(child.nodeType === Node.TEXT_NODE){
+        md += child.textContent;
+      }else if(child.nodeType === Node.ELEMENT_NODE){
+        var tag = child.tagName.toLowerCase();
+        switch(tag){
+          case 'strong':
+          case 'b':
+            md += '**' + process(child) + '**';
+            break;
+          case 'em':
+          case 'i':
+            md += '_' + process(child) + '_';
+            break;
+          case 'br':
+            md += '\n';
+            break;
+          case 'p':
+            md += process(child) + '\n\n';
+            break;
+          case 'a':
+            md += '[' + process(child) + '](' + child.getAttribute('href') + ')';
+            break;
+          case 'ul':
+            md += Array.from(child.children).map(function(li){
+              return '- ' + process(li);
+            }).join('\n') + '\n';
+            break;
+          case 'ol':
+            md += Array.from(child.children).map(function(li,i){
+              return (i+1) + '. ' + process(li);
+            }).join('\n') + '\n';
+            break;
+          case 'code':
+            md += '`' + child.textContent + '`';
+            break;
+          case 'pre':
+            md += '```\n' + child.textContent + '\n```\n';
+            break;
+          default:
+            md += process(child);
+        }
+      }
+    });
+    return md;
+  }
+
+  function turndown(html){
+    var div = document.createElement('div');
+    div.innerHTML = html;
+    return process(div).replace(/\n{3,}/g,'\n\n').trim();
+  }
+
+  function TurndownService(){}
+  TurndownService.prototype.turndown = turndown;
+
+  window.TurndownService = TurndownService;
+})();


### PR DESCRIPTION
## Summary
- include a simple `turndown.js` implementation
- add `html2md.js` for converting Gmail HTML back to Markdown
- register new context menu and command in `background.js`
- expose new command in `manifest.json`
- document HTML-to-Markdown feature

## Testing
- `npm test` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_6854007e1e088323ab9aa6ffc0581c21