### PR TITLE
Improve Markdown handling

### DIFF
--- a/html2md.js
+++ b/html2md.js
@@ -1,5 +1,5 @@
 (function(){
-  console.log('[Markdown4Gmail] html2md.js loaded');
+  'use strict';
   const MAX_ATTEMPTS = 50;
   let attempts = 0;
 
@@ -18,6 +18,7 @@
         const md = td.turndown(div.innerHTML);
         range.deleteContents();
         range.insertNode(document.createTextNode(md));
+        range.collapse(false);
       }else{
         const md = td.turndown(emailBody.innerHTML);
         emailBody.innerText = md;

--- a/injector.js
+++ b/injector.js
@@ -1,13 +1,11 @@
 (function () {
-  console.log('[Markdown4Gmail] injector.js loaded');
+  'use strict';
 
   const MAX_ATTEMPTS = 50;
   let attempts = 0;
 
   const interval = setInterval(() => {
     const emailBody = document.querySelector('div[aria-label="Message Body"][contenteditable="true"]');
-    console.log(`[Markdown4Gmail] Attempt ${attempts}, emailBody found: ${!!emailBody}`);
-    console.log(`[Markdown4Gmail] typeof marked: ${typeof marked}`);
 
     if (emailBody && typeof marked?.parse === 'function') {
       clearInterval(interval);
@@ -22,7 +20,10 @@
             const tempContainer = document.createElement('div');
             tempContainer.innerHTML = marked.parse(selectedText, { gfm: opts.gfm, sanitize: opts.sanitize });
             range.deleteContents();
-            range.insertNode(tempContainer);
+            while (tempContainer.firstChild) {
+              range.insertNode(tempContainer.firstChild);
+              range.collapse(false);
+            }
           }
         } else {
           const markdown = emailBody.innerText;
@@ -34,7 +35,6 @@
       attempts++;
       if (attempts > MAX_ATTEMPTS) {
         clearInterval(interval);
-        console.log("[Markdown4Gmail] Still couldn't find the email body or Markdown parser after waiting.");
       }
     }
   }, 300);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Markdown for Gmail",
-  "version": "1.0",
+  "version": "1.1",
   "description": "Write emails in Markdown and convert them to rich text via right-click or shortcut.",
   "permissions": ["contextMenus", "scripting", "activeTab", "storage"],
   "host_permissions": ["https://mail.google.com/*"],


### PR DESCRIPTION
## Summary
- clean up console output and enable strict mode
- insert converted HTML nodes individually
- collapse selection range after HTML insertion
- bump extension version to 1.1

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685403252cc4832388efbb6853f45d90