### PR TITLE
Add slack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Markdown for Gmail Chrome Extension
+# Markdown for Gmail and Slack Chrome Extension
 
-This extension allows you to write emails in Markdown when composing a message in Gmail. Convert the Markdown to rich text via the provided context menu item or with the keyboard shortcut `Ctrl+Shift+M`.
+This extension allows you to write emails in Markdown when composing a message in Gmail and also supports writing Slack messages in Markdown. Convert the Markdown to rich text via the provided context menu item or with the keyboard shortcut `Ctrl+Shift+M`.
 
 An options page allows you to configure automatic conversion on paste, parser settings, emoji support, and a custom keyboard shortcut. The shortcut string recognizes `ctrl`, `shift`, `alt`, and `cmd`/`meta` tokens so macOS users can specify combinations like `cmd+shift+m`.
 
@@ -11,10 +11,10 @@ An options page allows you to configure automatic conversion on paste, parser se
 4. Click **Load unpacked** and choose this folder.
 
 ## Usage
-- Compose a new email in Gmail and write your message using Markdown syntax.
-- Right-click inside the message body and choose **Convert Markdown to Rich Text**, or press `Ctrl+Shift+M`.
-- Use **Convert HTML to Markdown** from the context menu (or `Ctrl+Shift+H`) to reverse the conversion.
-- The extension will convert the Markdown to HTML within the compose area or convert existing HTML back to Markdown when requested.
+- Compose a new email in Gmail or a message in Slack and write it using Markdown syntax.
+- Right-click inside the editable area and choose **Convert Markdown to Rich Text**, or press `Ctrl+Shift+M`.
+- Use **Convert HTML to Markdown** from the context menu (or `Ctrl+Shift+H`) to reverse the conversion in Gmail.
+- The extension converts the Markdown to rich text within the compose area and can convert existing HTML back to Markdown when requested.
 - Emoji shortcodes like `:smile:` are automatically converted to their corresponding characters.
 
 ## Development
@@ -27,5 +27,5 @@ The conversion is performed using the [Marked](https://github.com/markedjs/marke
 4. Follow the Chrome Web Store instructions to submit the extension for review and publication.
 5. Update the `version` field in `manifest.json` before submitting a new release.
 
-![Gmail Markdown conversion example](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6XdvFUAAAAASUVORK5CYII=)
+![Gmail/Slack Markdown conversion example](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6XdvFUAAAAASUVORK5CYII=)
 

--- a/contentScript.js
+++ b/contentScript.js
@@ -21,6 +21,10 @@
     thumbs_up: '👍'
   };
 
+  function getEditable() {
+    return document.querySelector('div[aria-label="Message Body"][contenteditable="true"], div[role="textbox"][contenteditable="true"]');
+  }
+
   function replaceEmojis(text) {
     return text.replace(/:([a-zA-Z0-9_+-]+):/g, (m, p1) => EMOJI_MAP[p1] || m);
   }
@@ -72,14 +76,14 @@
       }, true);
     }
 
-    const existing = document.querySelector('div[aria-label="Message Body"][contenteditable="true"]');
+    const existing = getEditable();
     if (existing) {
       attachListener(existing);
       return;
     }
 
     const observer = new MutationObserver(() => {
-      const body = document.querySelector('div[aria-label="Message Body"][contenteditable="true"]');
+      const body = getEditable();
       if (body) {
         attachListener(body);
         observer.disconnect();
@@ -90,7 +94,7 @@
 
   function observeSendButton(callback) {
     const observer = new MutationObserver(() => {
-      const btn = document.querySelector('div[aria-label^="Send"]');
+      const btn = document.querySelector('div[aria-label^="Send"], button[data-qa="texty_send_button"], button[aria-label="Send now"]');
       if (btn) {
         btn.addEventListener('click', () => callback(), true);
         observer.disconnect();
@@ -112,7 +116,7 @@
 
   function convertMarkdown(opts, markdownText) {
     loadMarked(() => {
-      const emailBody = document.querySelector('div[aria-label="Message Body"][contenteditable="true"]');
+      const emailBody = getEditable();
       if (!emailBody || typeof marked?.parse !== 'function') return;
       const selection = window.getSelection();
       const range = selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null;

--- a/html2md.js
+++ b/html2md.js
@@ -4,7 +4,7 @@
   let attempts = 0;
 
   const interval = setInterval(() => {
-    const emailBody = document.querySelector('div[aria-label="Message Body"][contenteditable="true"]');
+    const emailBody = document.querySelector('div[aria-label="Message Body"][contenteditable="true"], div[role="textbox"][contenteditable="true"]');
     if(emailBody && typeof TurndownService !== 'undefined'){
       clearInterval(interval);
       const selection = window.getSelection();

--- a/injector.js
+++ b/injector.js
@@ -22,7 +22,7 @@
   }
 
   const interval = setInterval(() => {
-    const emailBody = document.querySelector('div[aria-label="Message Body"][contenteditable="true"]');
+    const emailBody = document.querySelector('div[aria-label="Message Body"][contenteditable="true"], div[role="textbox"][contenteditable="true"]');
 
     if (emailBody && typeof marked?.parse === 'function') {
       clearInterval(interval);

--- a/manifest.json
+++ b/manifest.json
@@ -1,24 +1,24 @@
 {
   "manifest_version": 3,
-  "name": "Markdown for Gmail",
+  "name": "Markdown for Gmail and Slack",
   "version": "1.1",
-  "description": "Write emails in Markdown and convert them to rich text via right-click or shortcut.",
+  "description": "Write Gmail or Slack messages in Markdown and convert them to rich text via right-click or shortcut.",
   "permissions": ["contextMenus", "scripting", "activeTab", "storage"],
-  "host_permissions": ["https://mail.google.com/*"],
+  "host_permissions": ["https://mail.google.com/*", "https://*.slack.com/*"],
   "background": {
     "service_worker": "background.js"
   },
   "options_page": "options.html",
   "content_scripts": [
     {
-      "matches": ["https://mail.google.com/*"],
+      "matches": ["https://mail.google.com/*", "https://*.slack.com/*"],
       "js": ["contentScript.js"],
       "run_at": "document_idle"
     }
   ],
   "action": {
     "default_icon": "icons/icon.png",
-    "default_title": "Markdown for Gmail"
+    "default_title": "Markdown for Gmail and Slack"
   },
   "commands": {
     "convert_markdown": {
@@ -37,7 +37,7 @@
   "web_accessible_resources": [
     {
       "resources": ["marked.min.js", "turndown.js"],
-      "matches": ["https://mail.google.com/*"]
+      "matches": ["https://mail.google.com/*", "https://*.slack.com/*"]
     }
   ]
 }

--- a/options.html
+++ b/options.html
@@ -2,11 +2,11 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <title>Markdown for Gmail Options</title>
+  <title>Markdown for Gmail and Slack Options</title>
   <link rel="stylesheet" href="options.css">
 </head>
 <body>
-  <h1>Markdown for Gmail Options</h1>
+  <h1>Markdown for Gmail and Slack Options</h1>
   <label><input type="checkbox" id="convertOnPaste"> Convert on Paste</label><br>
   <label><input type="checkbox" id="autoConvert"> Convert on Send</label><br>
   <label><input type="checkbox" id="gfm"> GitHub flavored Markdown</label><br>


### PR DESCRIPTION
## Summary
- allow Markdown conversion on Slack domains
- update docs and options page text for Gmail & Slack usage
- generalize selectors so editable area and send button work in Slack

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541ba6302c8323b1ca805943f7b237