### PR TITLE
Fix Slack paste conversion

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -70,7 +70,6 @@
         const text = e.clipboardData.getData('text/plain');
         if (text) {
           e.preventDefault();
-          e.stopImmediatePropagation();
           callback(text);
         }
       }, true);
@@ -132,6 +131,7 @@
           range.deleteContents();
           range.insertNode(temp);
         }
+        emailBody.dispatchEvent(new Event('input', { bubbles: true }));
         return;
       }
 
@@ -144,6 +144,7 @@
         const html = marked.parse(replaceEmojis(emailBody.innerText), markedOpts);
         emailBody.innerHTML = html;
       }
+      emailBody.dispatchEvent(new Event('input', { bubbles: true }));
     });
   }
 })();


### PR DESCRIPTION
## Summary
- remove stopImmediatePropagation when listening for paste
- trigger an `input` event after inserting HTML so Slack updates its editor state

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541d4c2ed08323ae5e392754650ce5