### PR TITLE
Fix custom shortcut update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This extension allows you to write emails in Markdown when composing a message in Gmail and also supports writing Slack messages in Markdown. Convert the Markdown to rich text via the provided context menu item or with the keyboard shortcut `Ctrl+Shift+M`.
 
-An options page allows you to configure automatic conversion on paste, parser settings, emoji support, and a custom keyboard shortcut. The shortcut string recognizes `ctrl`, `shift`, `alt`, and `cmd`/`meta` tokens so macOS users can specify combinations like `cmd+shift+m`.
+An options page allows you to configure automatic conversion on paste, parser settings, emoji support, and a custom keyboard shortcut. The shortcut string recognizes `ctrl`, `shift`, `alt`, and `cmd`/`meta` tokens so macOS users can specify combinations like `cmd+shift+m`. When you save a new shortcut it is applied to the extension's command automatically, so there is no need to update it through the **Extension shortcuts** page.
 
 ## Installation
 1. Clone this repository.

--- a/options.css
+++ b/options.css
@@ -12,3 +12,10 @@ label {
 button {
   margin-top: 10px;
 }
+
+.hint {
+  font-size: 12px;
+  color: #555;
+  margin-top: -8px;
+  margin-bottom: 10px;
+}

--- a/options.html
+++ b/options.html
@@ -11,7 +11,8 @@
   <label><input type="checkbox" id="autoConvert"> Convert on Send</label><br>
   <label><input type="checkbox" id="gfm"> GitHub flavored Markdown</label><br>
   <label><input type="checkbox" id="sanitize"> Sanitize HTML</label><br>
-  <label>Custom Shortcut: <input type="text" id="shortcut" placeholder="Ctrl+Shift+M or Cmd+Shift+M"></label><br>
+  <label>Custom Shortcut: <input type="text" id="shortcut" placeholder="Ctrl+Shift+M or Cmd+Shift+M"></label>
+  <div class="hint">Saving will also update the extension's command shortcut.</div><br>
   <label><input type="checkbox" id="disableDefault"> Disable default shortcut</label><br>
   <button id="save">Save</button>
   <div id="status"></div>

--- a/options.js
+++ b/options.js
@@ -15,6 +15,13 @@ function saveOptions() {
         status.textContent = '';
       }, 1500);
     }
+    if (chrome.commands && chrome.commands.update) {
+      chrome.commands.update({ name: 'convert_markdown', shortcut: opts.shortcut }, () => {
+        if (chrome.runtime.lastError) {
+          console.warn('Failed to update command shortcut', chrome.runtime.lastError);
+        }
+      });
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- update shortcut command when saving options
- clarify shortcut info in README
- display hint for custom shortcut in options
- tweak options styles for hint

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541db9c8f883239ae8abd0d1755143