### PR TITLE
Fix unit test for Markdown header

### DIFF
--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -5,7 +5,7 @@ const TurndownService = require('turndown');
 describe('Markdown conversion', function() {
   it('converts Markdown to HTML', function() {
     const html = marked.parse('# Hello').trim();
-    assert.equal(html, '<h1 id="hello">Hello</h1>');
+    assert.equal(html, '<h1>Hello</h1>');
   });
 
   it('converts HTML to Markdown', function() {


### PR DESCRIPTION
## Summary
- update `conversion.test.js` to expect default `<h1>` output from `marked`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685428bff0248323b42c67cd839d7ad7