### PR TITLE
Add readable link conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ An options page allows you to configure automatic conversion on paste, parser se
 - Use **Convert HTML to Markdown** from the context menu (or `Ctrl+Shift+H`) to reverse the conversion in Gmail.
 - The extension converts the Markdown to rich text within the compose area and can convert existing HTML back to Markdown when requested.
 - Emoji shortcodes like `:smile:` are automatically converted to their corresponding characters.
+- Links written as `[text](url)` become plain `text (url)` links for readability.
 - Choose between *clean*, *Notion-style*, or *email-friendly* themes for rendered Markdown.
 - Typing `/note` or `/table` expands to a blockquote or table template.
 

--- a/contentScript.js
+++ b/contentScript.js
@@ -30,6 +30,10 @@
     return text.replace(/:([a-zA-Z0-9_+-]+):/g, (m, p1) => EMOJI_MAP[p1] || m);
   }
 
+  function convertLinksToReadable(text) {
+    return text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1 ($2)');
+  }
+
   function applyTheme(theme) {
     const id = 'md-theme-style';
     let link = document.getElementById(id);
@@ -175,7 +179,8 @@
       const markedOpts = { gfm: opts.gfm, sanitize: opts.sanitize };
 
       if (markdownText !== undefined) {
-        const html = marked.parse(replaceEmojis(markdownText), markedOpts);
+        const converted = convertLinksToReadable(markdownText);
+        const html = marked.parse(replaceEmojis(converted), markedOpts);
         if (document.queryCommandSupported && document.queryCommandSupported('insertHTML')) {
           document.execCommand('insertHTML', false, html);
         } else if (range) {
@@ -190,11 +195,13 @@
 
       if (range && emailBody.contains(range.commonAncestorContainer) && selection.toString().trim()) {
         const tempContainer = document.createElement('div');
-        tempContainer.innerHTML = marked.parse(replaceEmojis(selection.toString()), markedOpts);
+        const converted = convertLinksToReadable(selection.toString());
+        tempContainer.innerHTML = marked.parse(replaceEmojis(converted), markedOpts);
         range.deleteContents();
         range.insertNode(tempContainer);
       } else {
-        const html = marked.parse(replaceEmojis(emailBody.innerText), markedOpts);
+        const converted = convertLinksToReadable(emailBody.innerText);
+        const html = marked.parse(replaceEmojis(converted), markedOpts);
         emailBody.innerHTML = html;
       }
       emailBody.dispatchEvent(new Event('input', { bubbles: true }));


### PR DESCRIPTION
## Summary
- convert `[text](url)` Markdown links into `text (url)` before rendering
- document link conversion feature in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68542cffba34832394a321afe726a124