### PR TITLE
Add callout block for /note command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An options page allows you to configure automatic conversion on paste, parser se
 - Automatically convert text on paste or when sending the message.
 - Supports GitHub‑flavored Markdown and optional HTML sanitization.
 - Extensive emoji shortcode map with characters left intact when typed directly.
-- Slash commands `/note` and `/table` expand to useful templates.
+- Slash command `/note` inserts a callout block with editable text.
 - Choose between *clean*, *Notion-style*, or *email-friendly* themes.
 - Configure a custom keyboard shortcut or disable the default one.
 
@@ -32,7 +32,7 @@ An options page allows you to configure automatic conversion on paste, parser se
 - Emoji characters you type directly, like 👍, stay unchanged when converting.
 - Links written as `[text](url)` become plain `text (url)` links for readability.
 - Choose between *clean*, *Notion-style*, or *email-friendly* themes for rendered Markdown.
-- Typing `/note` or `/table` expands to a blockquote or table template.
+- Typing `/note` inserts a grey callout block to highlight important info.
 
 ## Development
 The conversion is performed using the [Marked](https://github.com/markedjs/marked) library which is bundled inside `injector.js`.

--- a/contentScript.js
+++ b/contentScript.js
@@ -64,13 +64,28 @@
         }
         const text = container.textContent;
         if (text.slice(idx - 5, idx) === '/note') {
-          container.textContent = text.slice(0, idx - 5) + '> ';
-          sel.collapse(container, idx - 3);
-          e.preventDefault();
-        } else if (text.slice(idx - 6, idx) === '/table') {
-          const tmpl = '| Header 1 | Header 2 |\n| --- | --- |\n| Cell 1 | Cell 2 |';
-          container.textContent = text.slice(0, idx - 6) + tmpl;
-          sel.collapse(container, idx - 6 + tmpl.length);
+          container.textContent = text.slice(0, idx - 5);
+          sel.collapse(container, idx - 5);
+          const html =
+            '<div class="md-callout" contenteditable="true" ' +
+            'style="background:#f2f2f2;padding:8px;border-radius:4px;">' +
+            'Important info</div>';
+          if (
+            document.queryCommandSupported &&
+            document.queryCommandSupported('insertHTML')
+          ) {
+            document.execCommand('insertHTML', false, html);
+          } else {
+            const temp = document.createElement('div');
+            temp.innerHTML = html;
+            const node = temp.firstChild;
+            const r = sel.getRangeAt(0);
+            r.insertNode(node);
+            r.setStart(node, 0);
+            r.collapse(true);
+            sel.removeAllRanges();
+            sel.addRange(r);
+          }
           e.preventDefault();
         }
       });

--- a/test/features.test.js
+++ b/test/features.test.js
@@ -33,7 +33,7 @@ describe('Extension features', function() {
     assert.isTrue(body.classList.contains('md-theme-notion'));
   });
 
-  it('expands /note and /table snippets', function() {
+  it('inserts a callout block with /note', function() {
     const script = loadScript('<div aria-label="Message Body" contenteditable="true"></div>');
     const body = document.querySelector('div[aria-label="Message Body"]');
     body.textContent = 'hello /note';
@@ -44,15 +44,6 @@ describe('Extension features', function() {
     window.getSelection().removeAllRanges();
     window.getSelection().addRange(range);
     body.dispatchEvent(new window.KeyboardEvent('keydown', { key: ' ' }));
-    assert.equal(body.textContent, 'hello > ');
-
-    body.textContent = '/table';
-    const range2 = document.createRange();
-    range2.selectNodeContents(body);
-    range2.collapse(false);
-    window.getSelection().removeAllRanges();
-    window.getSelection().addRange(range2);
-    body.dispatchEvent(new window.KeyboardEvent('keydown', { key: ' ' }));
-    assert.include(body.textContent, '| Header 1 | Header 2 |');
+    assert.include(body.innerHTML, 'md-callout');
   });
 });

--- a/themes.css
+++ b/themes.css
@@ -9,3 +9,10 @@
 .md-theme-email h1,
 .md-theme-email h2 { margin: 0.8em 0; font-size: 1em; font-weight: bold; }
 .md-theme-email blockquote { margin: 0.8em 0; padding-left: 8px; border-left: 4px solid #ccc; color: #000; }
+
+.md-callout {
+  background: #f2f2f2;
+  padding: 8px;
+  border-left: 4px solid #ccc;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- insert a callout block with `/note`
- remove the `/table` shortcut
- test the callout block
- document the new `/note` behaviour
- style `.md-callout`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685435f1eb3c8323b8f18041bd50f42d