### PR TITLE
Improve /note troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ An options page allows you to configure automatic conversion on paste, parser se
 ## Development
 The conversion is performed using the [Marked](https://github.com/markedjs/marked) library which is bundled inside `injector.js`.
 
+For troubleshooting features like the `/note` slash command, you can enable verbose
+logging by setting `window.GM_DEBUG = true` in the page's developer console.
+
 ## Packaging
 1. Ensure that all extension files are present and any build steps have been run.
 2. Compress the entire extension folder into a `.zip` archive. This is the package that will be uploaded.

--- a/contentScript.js
+++ b/contentScript.js
@@ -8,6 +8,10 @@
     shortcut: 'Ctrl+Shift+M',
     disableDefault: false
   };
+  const DEBUG = typeof window !== 'undefined' && window.GM_DEBUG;
+  function debugLog(...args) {
+    if (DEBUG) console.log('[gmail-md]', ...args);
+  }
   const EMOJI_MAP = typeof window !== "undefined" && window.EMOJI_MAP ? window.EMOJI_MAP : {};
 
 
@@ -63,7 +67,9 @@
           }
         }
         const text = container.textContent;
+        debugLog('shortcut check', { key: e.key, text, idx });
         if (text.slice(idx - 5, idx) === '/note') {
+          debugLog('inserting callout');
           container.textContent = text.slice(0, idx - 5);
           sel.collapse(container, idx - 5);
           const html =


### PR DESCRIPTION
## Summary
- expose debug flag via `window.GM_DEBUG`
- log when shortcut detection runs and when the callout block is inserted
- document debug flag in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685437fef9a483239a0b8f946d009ae1