### PR TITLE
Remove deprecated /note snippet feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ An options page allows you to configure automatic conversion on paste, parser se
 - Automatically convert text on paste or when sending the message.
 - Supports GitHub‑flavored Markdown and optional HTML sanitization.
 - Extensive emoji shortcode map with characters left intact when typed directly.
-- Slash command `/note` inserts a callout block with editable text.
 - Choose between *clean*, *Notion-style*, or *email-friendly* themes.
 - Configure a custom keyboard shortcut or disable the default one.
 
@@ -32,13 +31,10 @@ An options page allows you to configure automatic conversion on paste, parser se
 - Emoji characters you type directly, like 👍, stay unchanged when converting.
 - Links written as `[text](url)` become plain `text (url)` links for readability.
 - Choose between *clean*, *Notion-style*, or *email-friendly* themes for rendered Markdown.
-- Typing `/note` inserts a grey callout block to highlight important info.
 
 ## Development
 The conversion is performed using the [Marked](https://github.com/markedjs/marked) library which is bundled inside `injector.js`.
 
-For troubleshooting features like the `/note` slash command, you can enable verbose
-logging by setting `window.GM_DEBUG = true` in the page's developer console.
 
 ## Packaging
 1. Ensure that all extension files are present and any build steps have been run.

--- a/contentScript.js
+++ b/contentScript.js
@@ -48,69 +48,13 @@
     }
   }
 
-  function observeShortcuts() {
-    function attachListener(body) {
-      body.addEventListener('keydown', (e) => {
-        if (e.key !== ' ' && e.key !== 'Enter') return;
-        const sel = window.getSelection();
-        if (!sel.rangeCount) return;
-        const range = sel.getRangeAt(0);
-        if (!body.contains(range.startContainer)) return;
-        let container = range.startContainer;
-        let idx = range.startOffset;
-        if (container.nodeType !== Node.TEXT_NODE) {
-          if (container.lastChild && container.lastChild.nodeType === Node.TEXT_NODE) {
-            container = container.lastChild;
-            idx = container.textContent.length;
-          } else {
-            return;
-          }
-        }
-        const text = container.textContent;
-        debugLog('shortcut check', { key: e.key, text, idx });
-        if (text.slice(idx - 5, idx) === '/note') {
-          debugLog('inserting callout');
-          container.textContent = text.slice(0, idx - 5);
-          sel.collapse(container, idx - 5);
-          const html =
-            '<div class="md-callout" contenteditable="true" ' +
-            'style="background:#f2f2f2;padding:8px;border-radius:4px;">' +
-            'Important info</div>';
-          if (
-            document.queryCommandSupported &&
-            document.queryCommandSupported('insertHTML')
-          ) {
-            document.execCommand('insertHTML', false, html);
-          } else {
-            const temp = document.createElement('div');
-            temp.innerHTML = html;
-            const node = temp.firstChild;
-            const r = sel.getRangeAt(0);
-            r.insertNode(node);
-            r.setStart(node, 0);
-            r.collapse(true);
-            sel.removeAllRanges();
-            sel.addRange(r);
-          }
-          e.preventDefault();
-        }
-      });
-    }
-    const existing = getEditable();
-    if (existing) attachListener(existing);
-    const observer = new MutationObserver(() => {
-      const body = getEditable();
-      if (body) attachListener(body);
-    });
-    observer.observe(document.body, { childList: true, subtree: true });
-  }
+  function observeShortcuts() {}
 
   if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.sync) {
     chrome.storage.sync.get(DEFAULTS, (opts) => {
       const { convertOnPaste, autoConvert, shortcut, theme } = opts;
 
     applyTheme(theme);
-    observeShortcuts();
 
     if (convertOnPaste) {
       observePaste((text) => convertMarkdown(opts, text));
@@ -234,11 +178,10 @@
   }
 
   if (typeof module !== 'undefined') {
-    module.exports = {
-      convertLinksToReadable,
-      matchesShortcut,
-      applyTheme,
-      observeShortcuts
-    };
+      module.exports = {
+        convertLinksToReadable,
+        matchesShortcut,
+        applyTheme
+      };
   }
 })();

--- a/test/features.test.js
+++ b/test/features.test.js
@@ -33,17 +33,4 @@ describe('Extension features', function() {
     assert.isTrue(body.classList.contains('md-theme-notion'));
   });
 
-  it('inserts a callout block with /note', function() {
-    const script = loadScript('<div aria-label="Message Body" contenteditable="true"></div>');
-    const body = document.querySelector('div[aria-label="Message Body"]');
-    body.textContent = 'hello /note';
-    script.observeShortcuts();
-    const range = document.createRange();
-    range.selectNodeContents(body);
-    range.collapse(false);
-    window.getSelection().removeAllRanges();
-    window.getSelection().addRange(range);
-    body.dispatchEvent(new window.KeyboardEvent('keydown', { key: ' ' }));
-    assert.include(body.innerHTML, 'md-callout');
-  });
 });

--- a/themes.css
+++ b/themes.css
@@ -10,9 +10,3 @@
 .md-theme-email h2 { margin: 0.8em 0; font-size: 1em; font-weight: bold; }
 .md-theme-email blockquote { margin: 0.8em 0; padding-left: 8px; border-left: 4px solid #ccc; color: #000; }
 
-.md-callout {
-  background: #f2f2f2;
-  padding: 8px;
-  border-left: 4px solid #ccc;
-  border-radius: 4px;
-}


### PR DESCRIPTION
## Summary
- drop documentation for the `/note` callout
- strip callout handler from `contentScript.js`
- delete the `/note` test
- remove `.md-callout` CSS rule

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854395d1f7083239bc8c8581073dd29