### PR TITLE
feat: add Copy Thread as Markdown button to email reading view

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Markdown for Gmail",
   "version": "1.4.1",
   "description": "Write Gmail messages in Markdown and convert them to rich text via right-click or shortcut.",
-  "permissions": ["contextMenus", "scripting", "activeTab", "storage"],
+  "permissions": ["contextMenus", "scripting", "activeTab", "storage", "clipboardWrite"],
   "host_permissions": ["https://mail.google.com/*"],
   "background": {
     "service_worker": "background.js"
@@ -12,7 +12,7 @@
   "content_scripts": [
     {
       "matches": ["https://mail.google.com/*"],
-      "js": ["marked.min.js", "emoji.js", "contentScript.js"],
+      "js": ["marked.min.js", "emoji.js", "contentScript.js", "threadCopy.js"],
       "run_at": "document_idle"
     }
   ],

--- a/threadCopy.js
+++ b/threadCopy.js
@@ -1,0 +1,251 @@
+(function () {
+  const BTN_ID = 'md-copy-thread-btn';
+
+  // --- HTML to Markdown conversion ---
+
+  function processTable(tableEl) {
+    const rows = Array.from(tableEl.querySelectorAll('tr'));
+    if (!rows.length) return '';
+    const cellText = row =>
+      Array.from(row.querySelectorAll('th, td'))
+        .map(cell => processNode(cell).trim().replace(/\n/g, ' ').replace(/\|/g, '\\|'));
+    const headers = cellText(rows[0]);
+    let md = '| ' + headers.join(' | ') + ' |\n';
+    md += '| ' + headers.map(() => '---').join(' | ') + ' |\n';
+    rows.slice(1).forEach(row => { md += '| ' + cellText(row).join(' | ') + ' |\n'; });
+    return md + '\n';
+  }
+
+  function processNode(node) {
+    let md = '';
+    node.childNodes.forEach(function (child) {
+      if (child.nodeType === Node.TEXT_NODE) {
+        md += child.textContent;
+        return;
+      }
+      if (child.nodeType !== Node.ELEMENT_NODE) return;
+      const tag = child.tagName.toLowerCase();
+      switch (tag) {
+        case 'strong': case 'b': {
+          const inner = processNode(child).trim();
+          md += inner ? '**' + inner + '**' : '';
+          break;
+        }
+        case 'em': case 'i': {
+          const inner = processNode(child).trim();
+          md += inner ? '_' + inner + '_' : '';
+          break;
+        }
+        case 'br':
+          md += '\n';
+          break;
+        case 'p':
+          md += processNode(child).trim() + '\n\n';
+          break;
+        case 'div': {
+          const inner = processNode(child).trim();
+          md += inner ? inner + '\n' : '\n';
+          break;
+        }
+        case 'h1': case 'h2': case 'h3': case 'h4': case 'h5': case 'h6': {
+          const level = parseInt(tag[1], 10);
+          md += '#'.repeat(level) + ' ' + processNode(child).trim() + '\n\n';
+          break;
+        }
+        case 'a': {
+          const text = processNode(child).trim();
+          const href = child.getAttribute('href') || '';
+          md += text ? '[' + text + '](' + href + ')' : (href || '');
+          break;
+        }
+        case 'ul': {
+          child.querySelectorAll(':scope > li').forEach(li => {
+            md += '- ' + processNode(li).trim().replace(/\n/g, ' ') + '\n';
+          });
+          md += '\n';
+          break;
+        }
+        case 'ol': {
+          let i = 1;
+          child.querySelectorAll(':scope > li').forEach(li => {
+            md += i++ + '. ' + processNode(li).trim().replace(/\n/g, ' ') + '\n';
+          });
+          md += '\n';
+          break;
+        }
+        case 'code':
+          md += '`' + child.textContent + '`';
+          break;
+        case 'pre': {
+          const codeEl = child.querySelector('code');
+          md += '```\n' + (codeEl || child).textContent.trim() + '\n```\n\n';
+          break;
+        }
+        case 'blockquote': {
+          const inner = processNode(child).trim();
+          md += inner.split('\n').map(l => '> ' + l).join('\n') + '\n\n';
+          break;
+        }
+        case 'hr':
+          md += '\n---\n\n';
+          break;
+        case 'img': {
+          const alt = child.getAttribute('alt') || '';
+          if (alt) md += '[image: ' + alt + ']';
+          break;
+        }
+        case 'table':
+          md += processTable(child);
+          break;
+        case 'script': case 'style': case 'head':
+          break;
+        default:
+          md += processNode(child);
+      }
+    });
+    return md;
+  }
+
+  function htmlToMarkdown(el) {
+    return processNode(el)
+      .replace(/[ \t]+$/gm, '')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim();
+  }
+
+  // --- Thread extraction ---
+
+  function extractThread() {
+    const subjectEl = document.querySelector('h2.hP');
+    const subject = subjectEl ? subjectEl.textContent.trim() : '';
+    let result = subject ? '# ' + subject + '\n\n' : '';
+
+    const messages = document.querySelectorAll('.gs');
+    let addedCount = 0;
+
+    messages.forEach(function (msg) {
+      const bodyEl = msg.querySelector('.a3s');
+      if (!bodyEl) return;
+
+      const clone = bodyEl.cloneNode(true);
+      // Strip signatures, quoted content, attribution lines, and quote toggles
+      ['.gmail_signature', '.gmail_extra', '.gmail_quote', '.gmail_quote_container', '.gmail_attr']
+        .forEach(sel => clone.querySelectorAll(sel).forEach(el => el.remove()));
+
+      const text = htmlToMarkdown(clone);
+      if (!text.trim()) return;
+
+      const senderName = (msg.querySelector('.go') || {}).textContent || '';
+      const senderEmailEl = msg.querySelector('[email]');
+      const senderEmail = senderEmailEl ? senderEmailEl.getAttribute('email') : '';
+      const dateEl = msg.querySelector('.g3');
+      const date = dateEl ? (dateEl.getAttribute('title') || dateEl.textContent || '') : '';
+
+      if (addedCount > 0) result += '\n---\n\n';
+      addedCount++;
+
+      const trimmedName = senderName.trim();
+      const trimmedEmail = senderEmail.trim();
+      const from = trimmedEmail && trimmedEmail !== trimmedName
+        ? trimmedName + (trimmedName ? ' <' + trimmedEmail + '>' : trimmedEmail)
+        : trimmedName || trimmedEmail;
+
+      if (from) result += '**From:** ' + from + '\n';
+      if (date.trim()) result += '**Date:** ' + date.trim() + '\n';
+      if (from || date.trim()) result += '\n';
+
+      result += text + '\n';
+    });
+
+    return result.trim();
+  }
+
+  // --- Clipboard ---
+
+  async function copyToClipboard(text) {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch (_) {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.cssText = 'position:fixed;opacity:0;top:0;left:0;width:1px;height:1px';
+      document.body.appendChild(ta);
+      ta.focus();
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+    }
+  }
+
+  // --- Button injection ---
+
+  function showFeedback(btn, success) {
+    const origText = btn.textContent;
+    const origBg = btn.style.background;
+    const origBorder = btn.style.borderColor;
+    btn.textContent = success ? 'Copied!' : 'Copy failed';
+    btn.style.background = success ? '#e6f4ea' : '#fce8e6';
+    btn.style.borderColor = success ? '#81c784' : '#e57373';
+    setTimeout(function () {
+      btn.textContent = origText;
+      btn.style.background = origBg;
+      btn.style.borderColor = origBorder;
+    }, 2000);
+  }
+
+  function injectButton() {
+    if (document.getElementById(BTN_ID)) return;
+    const subjectEl = document.querySelector('h2.hP');
+    if (!subjectEl) return;
+
+    const btn = document.createElement('button');
+    btn.id = BTN_ID;
+    btn.textContent = 'Copy thread as Markdown';
+    btn.title = 'Copy this email thread as Markdown, without signatures or quoted replies';
+    btn.style.cssText = [
+      'display:inline-block',
+      'margin:6px 0 4px 0',
+      'padding:5px 12px',
+      'font-size:12px',
+      'font-family:"Google Sans",Roboto,Arial,sans-serif',
+      'font-weight:500',
+      'line-height:16px',
+      'cursor:pointer',
+      'background:#fff',
+      'border:1px solid #dadce0',
+      'border-radius:4px',
+      'color:#444746',
+      'transition:background 0.15s,border-color 0.15s',
+      'vertical-align:middle'
+    ].join(';');
+
+    btn.addEventListener('mouseover', function () {
+      if (btn.style.background === '#fff') btn.style.background = '#f6f9fe';
+    });
+    btn.addEventListener('mouseout', function () {
+      if (btn.style.background === '#f6f9fe') btn.style.background = '#fff';
+    });
+
+    btn.addEventListener('click', async function () {
+      try {
+        const md = extractThread();
+        await copyToClipboard(md);
+        showFeedback(btn, true);
+      } catch (err) {
+        console.error('[gmail-md] Copy thread failed:', err);
+        showFeedback(btn, false);
+      }
+    });
+
+    subjectEl.insertAdjacentElement('afterend', btn);
+  }
+
+  const observer = new MutationObserver(function () {
+    if (!document.getElementById(BTN_ID) && document.querySelector('h2.hP')) {
+      injectButton();
+    }
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+  injectButton();
+})();


### PR DESCRIPTION
Injects a "Copy thread as Markdown" button below the subject heading when viewing an email thread. On click, it collects all visible messages in the thread, strips signatures (.gmail_signature, .gmail_extra) and quoted replies (.gmail_quote, .gmail_quote_container, .gmail_attr), then converts the remaining HTML to clean Markdown and copies it to the clipboard — ready to paste into an AI tool for analysis or response.

Each message is prefixed with From/Date metadata and separated by --- dividers. Conversion handles bold, italic, headings, lists, code blocks, blockquotes, links, and tables. Falls back to execCommand('copy') if the Clipboard API is unavailable.

https://claude.ai/code/session_016X5bUorCQa1pRyu4jincAu