### PR TITLE
fix: freeze button width during feedback to prevent label reflow

### DIFF
--- a/threadCopy.js
+++ b/threadCopy.js
@@ -207,6 +207,10 @@
   // --- Button injection ---
 
   function showFeedback(btn, success) {
+    // Freeze the rendered width before swapping text. Without this, the button
+    // shrinks when showing "Copied!" and Gmail's sibling label chips (External,
+    // Inbox, etc.) reflow onto the same line as the subject heading.
+    btn.style.width = btn.offsetWidth + 'px';
     const origText = btn.textContent;
     const origBg = btn.style.background;
     const origBorder = btn.style.borderColor;
@@ -217,6 +221,7 @@
       btn.textContent = origText;
       btn.style.background = origBg;
       btn.style.borderColor = origBorder;
+      btn.style.width = '';
     }, 2000);
   }
 


### PR DESCRIPTION
When the button text changed from "Copy thread as Markdown" to "Copied!", the button shrank, causing Gmail's sibling label chips (External, Inbox, etc.) to reflow onto the same line as the subject heading.

Fix: capture btn.offsetWidth before swapping the text and set it as an explicit inline width for the duration of the feedback period. The width is released (set back to '') when the original label is restored after 2s.

https://claude.ai/code/session_016X5bUorCQa1pRyu4jincAu